### PR TITLE
Use SLF4J-style formatting anchors

### DIFF
--- a/jbpm-form-modeler-core/jbpm-form-modeler-service/jbpm-form-modeler-service-core/src/main/java/org/jbpm/formModeler/core/config/builders/dataHolder/PojoDataHolderBuilder.java
+++ b/jbpm-form-modeler-core/jbpm-form-modeler-service/jbpm-form-modeler-service-core/src/main/java/org/jbpm/formModeler/core/config/builders/dataHolder/PojoDataHolderBuilder.java
@@ -42,7 +42,7 @@ public class PojoDataHolderBuilder implements DataHolderBuilder {
             Class.forName(config.getValue());
             return new PojoDataHolder(config.getHolderId(), config.getInputId(), config.getOutputId(), config.getValue(), config.getRenderColor());
         } catch (ClassNotFoundException e) {
-            log.warn("Unable to load class '{0}': {1}", config.getValue(), e);
+            log.warn("Unable to load class '{}'", config.getValue(), e);
         }
         return null;
     }

--- a/jbpm-form-modeler-sample-custom-types/jbpm-form-modeler-custom-file-type/src/main/java/org/jbpm/formModeler/core/fieldTypes/file/FileCustomType.java
+++ b/jbpm-form-modeler-sample-custom-types/jbpm-form-modeler-custom-file-type/src/main/java/org/jbpm/formModeler/core/fieldTypes/file/FileCustomType.java
@@ -203,7 +203,7 @@ public class FileCustomType implements CustomFieldType {
             out.flush();
             str = out.getBuffer().toString();
         } catch (Exception e) {
-            log.warn("Failed to process template for field '{0}': {1}", fieldName, e);
+            log.warn("Failed to process template for field '{}'", fieldName, e);
         }
         return str;
     }


### PR DESCRIPTION
`{0}` or `{1}` are not valid SLF4J formatting anchors and so no arguments were included in the log message.
