### PR TITLE
[GUVNOR-2166] showcase: don't build all GWT combinations

### DIFF
--- a/jbpm-form-modeler-showcase/pom.xml
+++ b/jbpm-form-modeler-showcase/pom.xml
@@ -762,27 +762,4 @@
     </plugins>
 
   </build>
-  <profiles>
-    <profile>
-      <id>fullProfile</id>
-      <activation>
-        <property>
-          <name>full</name>
-        </property>
-      </activation>
-      <build>
-        <plugins>
-          <plugin><!-- Keep in sync with soa profile -->
-            <groupId>org.codehaus.mojo</groupId>
-            <artifactId>gwt-maven-plugin</artifactId>
-            <configuration>
-              <!-- Build all GWT permutations and optimize them -->
-              <module>org.jbpm.formModeler.jBPMFormModeler</module>
-              <draftCompile>false</draftCompile>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-  </profiles>
 </project>


### PR DESCRIPTION
 * the showcase is used mainly for testing/showcasing
   and as such should not be used by end users. Building
   all the GWT combinations is thus not necessarry and it
   only prolongs the build. From now on the only 2
   combinations are being build, even when running with
   "full" profile

* the "full" profile was removed altogether as it contained
  only the GWT config