### PR TITLE
Fixes search for rules that have the default package

### DIFF
--- a/jbpm-form-modeler-panels/jbpm-form-modeler-editor/jbpm-form-modeler-editor-backend/src/main/java/org/jbpm/formModeler/panels/modeler/backend/indexing/query/FindFormsQuery.java
+++ b/jbpm-form-modeler-panels/jbpm-form-modeler-editor/jbpm-form-modeler-editor-backend/src/main/java/org/jbpm/formModeler/panels/modeler/backend/indexing/query/FindFormsQuery.java
@@ -19,7 +19,8 @@ import org.apache.lucene.search.Query;
 import org.drools.workbench.models.datamodel.util.PortablePreconditions;
 import org.jbpm.formModeler.panels.modeler.backend.indexing.model.terms.FormIndexTerm;
 import org.kie.workbench.common.services.refactoring.backend.server.query.NamedQuery;
-import org.kie.workbench.common.services.refactoring.backend.server.query.QueryBuilder;
+import org.kie.workbench.common.services.refactoring.backend.server.query.builder.BasicQueryBuilder;
+import org.kie.workbench.common.services.refactoring.backend.server.query.builder.QueryBuilder;
 import org.kie.workbench.common.services.refactoring.backend.server.query.response.DefaultResponseBuilder;
 import org.kie.workbench.common.services.refactoring.backend.server.query.response.ResponseBuilder;
 import org.kie.workbench.common.services.refactoring.model.index.terms.IndexTerm;
@@ -62,7 +63,7 @@ public class FindFormsQuery implements NamedQuery {
             throw new IllegalArgumentException( "Required term has not been provided. Require '" + FormIndexTerm.TERM + "'." );
         }
 
-        final QueryBuilder builder = new QueryBuilder();
+        final QueryBuilder builder = new BasicQueryBuilder();
         if ( useWildcards ) {
             builder.useWildcards();
         }


### PR DESCRIPTION
Bug 1257819 - GSS Rules are not populated in dropdown list in Test Scenarios in BRMS 6.1
Bug 1257817 - Rules are not populated in dropdown list in Test Scenarios in BRMS 6.1

This fix needs the following PRs:
https://github.com/droolsjbpm/kie-wb-common/pull/116
https://github.com/droolsjbpm/drools-wb/pull/78
https://github.com/droolsjbpm/jbpm-designer/pull/67
https://github.com/droolsjbpm/jbpm-form-modeler/pull/17
