### PR TITLE
RHBPMS-5065: In Form Modeler when we select option From Java Class and provide fully quilified class name (having more than 64 char) so can't generate a form.

### DIFF
--- a/jbpm-form-modeler-core/jbpm-form-modeler-service/jbpm-form-modeler-form-editor/src/main/webapp/formModeler/components/WysiwygFormEdit/menu/dataHoldersSources.jsp
+++ b/jbpm-form-modeler-core/jbpm-form-modeler-service/jbpm-form-modeler-form-editor/src/main/webapp/formModeler/components/WysiwygFormEdit/menu/dataHoldersSources.jsp
@@ -179,7 +179,7 @@
                             <tr>
                                 <td>
                                     <select class="skn-input" id="<%=WysiwygFormEditor.PARAMETER_HOLDER_COMBO_VALUE%>" name="<%=WysiwygFormEditor.PARAMETER_HOLDER_COMBO_VALUE%>" style="display: none"></select>
-                                    <input type="text" id="<%=WysiwygFormEditor.PARAMETER_HOLDER_INPUT_VALUE%>" name="<%=WysiwygFormEditor.PARAMETER_HOLDER_INPUT_VALUE%>"  class="skn-input" value="" size="20" maxlength="64" style="display: none">
+                                    <input type="text" id="<%=WysiwygFormEditor.PARAMETER_HOLDER_INPUT_VALUE%>" name="<%=WysiwygFormEditor.PARAMETER_HOLDER_INPUT_VALUE%>"  class="skn-input" value="" size="20" maxlength="512" style="display: none">
                                 </td>
                             </tr>
                         </table>


### PR DESCRIPTION
Increased input size to 512 instead of 64.

@jsoltes could you please review?